### PR TITLE
Export file as module

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,7 +12,9 @@ const bundleModule = function(args) {
 		entry: args.entry || "./index.js",
 		output: {
 			path: path.resolve(process.cwd(), args.output_dir || "./dist"),
-			libraryExport: args.export_name || "default"
+			libraryExport: args.export_name || undefined,
+			library: args.library || 'MyBundle',
+        	libraryTarget: args.libraryTarget || 'umd',
 		},
 		minified: (args.min || args.minified) ? true : false,
 		source_map: args.source_map || (args.min ? false : true ),

--- a/lib/generateConfig.js
+++ b/lib/generateConfig.js
@@ -12,7 +12,6 @@ function generateConfig(opts) {
 		output: {
 			path: opts.output.path,
 			filename: opts.output.filename,
-			library: opts.output.library,
         	libraryTarget: opts.output.libraryTarget,
 		},
 		mode: MODE,

--- a/lib/generateConfig.js
+++ b/lib/generateConfig.js
@@ -11,7 +11,9 @@ function generateConfig(opts) {
 		entry: opts.entry,
 		output: {
 			path: opts.output.path,
-			filename: opts.output.filename
+			filename: opts.output.filename,
+			library: opts.output.library,
+        	libraryTarget: opts.output.libraryTarget,
 		},
 		mode: MODE,
 		devtool: isDevelopment ? 'inline-source-map' : false,


### PR DESCRIPTION
The build file now exports a Promise which resolves to a module. We can use the "then" syntax within HTML docs to access the functions of the module within the success callback.